### PR TITLE
bugfix pagination, 'previous' link now working correctly

### DIFF
--- a/src/main/java/com/metalr2/web/controller/SearchArtistRestController.java
+++ b/src/main/java/com/metalr2/web/controller/SearchArtistRestController.java
@@ -9,7 +9,6 @@ import com.metalr2.web.controller.discogs.DiscogsArtistSearchRestClient;
 import com.metalr2.web.dto.FollowArtistDto;
 import com.metalr2.web.dto.discogs.search.DiscogsArtistSearchResultContainer;
 import com.metalr2.web.dto.discogs.search.DiscogsPagination;
-import com.metalr2.web.dto.discogs.search.DiscogsPaginationUrls;
 import com.metalr2.web.dto.request.ArtistSearchRequest;
 import com.metalr2.web.dto.response.ArtistNameSearchResponse;
 import com.metalr2.web.dto.response.Pagination;
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -33,11 +31,8 @@ import java.util.stream.Collectors;
 import static com.metalr2.web.dto.response.ArtistNameSearchResponse.ArtistSearchResult;
 
 @RestController
-@RequestMapping({Endpoints.Rest.ARTISTS_V1})
+@RequestMapping(Endpoints.Rest.ARTISTS_V1)
 public class SearchArtistRestController {
-
-  private static final int DEFAULT_PAGE_SIZE = 25;
-  private static final int DEFAULT_PAGE = 1;
 
   private final DiscogsArtistSearchRestClient artistSearchClient;
   private final FollowArtistService followArtistService;
@@ -51,11 +46,11 @@ public class SearchArtistRestController {
   @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE},
                produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ArtistNameSearchResponse> handleSearchRequest(@Valid @RequestBody ArtistSearchRequest artistSearchRequest,
-                                                                      BindingResult bindingResult, Authentication usernamePasswordAuthenticationToken) {
+                                                                      BindingResult bindingResult, Authentication authentication) {
     validateRequest(bindingResult);
 
-    ArtistNameSearchResponse artistNameSearchResponse = searchArtist(artistSearchRequest, ((UserEntity)usernamePasswordAuthenticationToken.getPrincipal()).getPublicId());
-    return artistNameSearchResponse.getArtistSearchResults().isEmpty() ? ResponseEntity.notFound().build() : ResponseEntity.ok(artistNameSearchResponse);
+    Optional<ArtistNameSearchResponse> artistNameSearchResponse = searchArtist(artistSearchRequest, ((UserEntity)authentication.getPrincipal()).getPublicId());
+    return ResponseEntity.of(artistNameSearchResponse);
   }
 
   private void validateRequest(BindingResult bindingResult) {
@@ -64,25 +59,19 @@ public class SearchArtistRestController {
     }
   }
 
-  private ArtistNameSearchResponse searchArtist(ArtistSearchRequest artistSearchRequest, String publicUserId) {
+  private Optional<ArtistNameSearchResponse> searchArtist(ArtistSearchRequest artistSearchRequest, String publicUserId) {
     Optional<DiscogsArtistSearchResultContainer> artistSearchResultsOptional = artistSearchClient.searchByName(artistSearchRequest.getArtistName(),
             artistSearchRequest.getPage(), artistSearchRequest.getSize());
 
-    if (artistSearchResultsOptional.isEmpty()) {
-      return new ArtistNameSearchResponse(Collections.emptyList(),new Pagination());
-    }
-
-    return createArtistNameSearchResponse(artistSearchResultsOptional.get(), publicUserId);
+    return artistSearchResultsOptional.isEmpty() ? Optional.empty() : createArtistNameSearchResponse(artistSearchResultsOptional.get(), publicUserId);
   }
 
-  private ArtistNameSearchResponse createArtistNameSearchResponse(DiscogsArtistSearchResultContainer artistSearchResults, String publicUserId) {
-    DiscogsPagination discogsPagination         = artistSearchResults.getDiscogsPagination();
-    DiscogsPaginationUrls discogsPaginationUrls = discogsPagination.getUrls();
+  private Optional<ArtistNameSearchResponse> createArtistNameSearchResponse(DiscogsArtistSearchResultContainer artistSearchResults, String publicUserId) {
+    DiscogsPagination discogsPagination = artistSearchResults.getDiscogsPagination();
 
-    int size      = discogsPaginationUrls.getNext() != null ? discogsPagination.getItemsPerPage() : DEFAULT_PAGE_SIZE;
-    int nextPage  = discogsPaginationUrls.getNext() != null ? discogsPagination.getCurrentPage() + 1 : DEFAULT_PAGE;
+    int itemsPerPage = discogsPagination.getItemsPerPage();
 
-   Set<Long> alreadyFollowedArtists = followArtistService.findPerUser(publicUserId).stream().map(FollowArtistDto::getArtistDiscogsId)
+    Set<Long> alreadyFollowedArtists = followArtistService.findPerUser(publicUserId).stream().map(FollowArtistDto::getArtistDiscogsId)
            .collect(Collectors.toSet());
 
     List<ArtistSearchResult> dtoArtistSearchResults = artistSearchResults.getResults().stream()
@@ -91,8 +80,8 @@ public class SearchArtistRestController {
             .collect(Collectors.toList());
 
     Pagination pagination = new Pagination(discogsPagination.getPagesTotal(), discogsPagination.getCurrentPage(),
-            size, nextPage);
+            itemsPerPage);
 
-    return new ArtistNameSearchResponse(dtoArtistSearchResults, pagination);
+    return Optional.of(new ArtistNameSearchResponse(dtoArtistSearchResults, pagination));
   }
 }

--- a/src/main/java/com/metalr2/web/dto/response/Pagination.java
+++ b/src/main/java/com/metalr2/web/dto/response/Pagination.java
@@ -11,7 +11,6 @@ public class Pagination {
 
   private int totalPages;
   private int currentPage;
-  private int size;
-  private int nextPage;
+  private int itemsPerPage;
 
 }

--- a/src/main/resources/static/js/search-artists.js
+++ b/src/main/resources/static/js/search-artists.js
@@ -119,6 +119,7 @@ const createPagination = function (artistNameSearchResponse) {
         const previousElement = document.createElement('a');
         previousElement.href = "#";
         previousElement.text = "Previous";
+        previousElement.className = "btn btn-dark btn-pagination";
         previousElement.onclick = (function (page, size) {
             return function () {
                 searchArtist(page, size)
@@ -133,6 +134,7 @@ const createPagination = function (artistNameSearchResponse) {
             const pageNumberElement = document.createElement('a');
             pageNumberElement.href = "#";
             pageNumberElement.text = index;
+            pageNumberElement.className = "btn btn-dark btn-pagination";
             pageNumberElement.onclick = (function (page, size) {
                 return function () {
                     searchArtist(page, size)
@@ -147,6 +149,7 @@ const createPagination = function (artistNameSearchResponse) {
         const nextElement = document.createElement('a');
         nextElement.href = "#";
         nextElement.text = "Next";
+        nextElement.className = "btn btn-dark btn-pagination";
         nextElement.onclick = (function (page, size) {
             return function () {
                 searchArtist(page, size)

--- a/src/main/resources/static/js/search-artists.js
+++ b/src/main/resources/static/js/search-artists.js
@@ -123,7 +123,7 @@ const createPagination = function (artistNameSearchResponse) {
             return function () {
                 searchArtist(page, size)
             };
-        })(artistNameSearchResponse.pagination.nextPage, artistNameSearchResponse.pagination.size);
+        })(artistNameSearchResponse.pagination.currentPage-1, artistNameSearchResponse.pagination.itemsPerPage);
 
         document.getElementById('paginationContainer').appendChild(previousElement);
     }
@@ -137,7 +137,7 @@ const createPagination = function (artistNameSearchResponse) {
                 return function () {
                     searchArtist(page, size)
                 };
-            })(index, artistNameSearchResponse.pagination.size);
+            })(index, artistNameSearchResponse.pagination.itemsPerPage);
 
             document.getElementById('paginationContainer').appendChild(pageNumberElement);
         }
@@ -151,7 +151,7 @@ const createPagination = function (artistNameSearchResponse) {
             return function () {
                 searchArtist(page, size)
             };
-        })(artistNameSearchResponse.pagination.nextPage, artistNameSearchResponse.pagination.size);
+        })(artistNameSearchResponse.pagination.currentPage+1, artistNameSearchResponse.pagination.itemsPerPage);
 
         document.getElementById('paginationContainer').appendChild(nextElement);
     }

--- a/src/test/java/com/metalr2/web/controller/SearchArtistRestControllerIT.java
+++ b/src/test/java/com/metalr2/web/controller/SearchArtistRestControllerIT.java
@@ -100,7 +100,7 @@ class SearchArtistRestControllerIT implements WithAssertions {
 
     Pagination pagination = artistNameSearchResponse.getPagination();
 
-    assertThat(pagination).isEqualTo(new Pagination(TOTAL_PAGES, DEFAULT_PAGE, DEFAULT_SIZE, DEFAULT_PAGE + 1));
+    assertThat(pagination).isEqualTo(new Pagination(TOTAL_PAGES, DEFAULT_PAGE, DEFAULT_SIZE));
 
     verify(artistSearchClient,times(1)).searchByName(artistSearchRequest.getArtistName(),artistSearchRequest.getPage(),artistSearchRequest.getSize());
   }


### PR DESCRIPTION
The 'previous' link of the pagination for artist search results did not work correctly. It also returned the next page. This is now fixed.