### PR TITLE
Add Dockerfile and docker-compose to start all peripheral systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 !**/src/main/**
 !**/src/test/**
 
-# ignore all stuff in private folder
+# ignore all stuff in .private folder
 .private/
+
+# ignore docker .secrets folder
+.secrets/
 
 # ignore all stuff in target folder
 target/
@@ -17,3 +20,6 @@ target/
 
 # ignore all logs
 *.log
+
+# docker env file
+src/main/docker/env.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:11-stretch
+
+ARG BUILD_DATE
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+COPY target/metal-release-radar-0.0.1.jar metal-release-radar.jar
+
+RUN sh -c 'touch /metal-release-radar.jar'
+
+EXPOSE 8090
+
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/metal-release-radar.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,104 @@
+version: '3.7'
+
+services: 
+  mrr-mysql: 
+    image: mysql:5
+    environment:
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/mrr_mysql_root_password
+      MYSQL_DATABASE: metal-release-radar
+      MYSQL_USER: db_metal_release_radar
+      MYSQL_PASSWORD_FILE: /run/secrets/mrr_mysql_password
+    secrets:
+      - mrr_mysql_root_password
+      - mrr_mysql_password
+    networks:
+      - mrr-network
+    volumes:
+      - type: volume
+        source: mrr-mysql-volume
+        target: /var/lib/mysql
+    ports:
+      - 3306:3306
+    restart: always
+     
+  mrr-phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    environment:
+     PMA_ARBITRARY: 1
+     PMA_HOST: mrr-mysql
+    networks:
+      - mrr-network
+    volumes:
+      - type: volume
+        source: mrr-phpmyadmin-volume
+        target: /sessions
+    ports:
+     - 9000:80
+    restart: always
+
+  mrr-butler-mysql:
+    image: mysql:5
+    environment:
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/mrr_butler_mysql_root_password
+      MYSQL_DATABASE: metal-release-butler
+      MYSQL_USER: db_metal_release_butler
+      MYSQL_PASSWORD_FILE: /run/secrets/mrr_butler_mysql_password
+    secrets:
+      - mrr_butler_mysql_root_password
+      - mrr_butler_mysql_password
+    networks:
+      - mrr-butler-network
+    volumes:
+      - type: volume
+        source: mrr-butler-mysql-volume
+        target: /var/lib/mysql  
+    ports:
+      - 3307:3306
+    restart: always
+
+  mrr-butler-phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    environment:
+     PMA_ARBITRARY: 1
+     PMA_HOST: mrr-butler-mysql
+    networks:
+      - mrr-butler-network
+    volumes:
+      - type: volume
+        source: mrr-butler-phpmyadmin-volume
+        target: /sessions
+    ports:
+     - 9001:80
+    restart: always
+
+  mrr-butler:
+    image: metalreleaseradar/metal-release-butler
+    environment:
+      DATASOURCE_URL: jdbc:mysql://mrr-butler-mysql:3306/metal-release-butler?useUnicode=true&characterEncoding=utf-8&serverTimezone=UTC&useSSL=false
+      DATASOURCE_USERNAME: root
+      DATASOURCE_PASSWORD: ${BUTLER_MYSQL_PASSWORD}
+    networks:
+      - mrr-butler-network
+    ports:
+      - 8095:8095
+    restart: always
+
+volumes:
+  mrr-mysql-volume:
+  mrr-phpmyadmin-volume:
+  mrr-butler-mysql-volume:
+  mrr-butler-phpmyadmin-volume:
+
+secrets:
+  mrr_mysql_root_password:
+    file: .secrets/mrr_mysql_root_password.txt
+  mrr_mysql_password:
+    file: .secrets/mrr_mysql_password.txt
+  mrr_butler_mysql_root_password:
+    file: .secrets/mrr_butler_mysql_root_password.txt
+  mrr_butler_mysql_password:
+    file: .secrets/mrr_butler_mysql_password.txt
+
+networks:
+  mrr-network:
+  mrr-butler-network:

--- a/metalreleaseradar.iml
+++ b/metalreleaseradar.iml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4" />

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Maven plugin for submitting Java code coverage reports to Coveralls web service. -->
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
@@ -279,6 +280,9 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <!-- JaCoCo is a free code coverage library for Java. It records which parts of your Java code are executed during a        -->
+            <!-- particular program launch. This technique is called code coverage analysis and typically used with automated           -->
+            <!-- testing like JUnit unit tests. It helps to identify untested parts of a code base and improve the corresponding tests. -->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
With this PR a first Dockerfile for the Metal Release Radar is added. We'll need the Dockerfile later to build a Docker Image from the Spring Boot application. This should work right now, but I haven't tested it yet, because it will be built by our build pipeline later. 

Furthermore the application now has a docker-compose.yml. This allows us to start all required peripheral systems of the application on the developer machine without having to install a local database server. Also an instance of the Release Butler is started.